### PR TITLE
cleaning up error handling on frontend

### DIFF
--- a/web-frontend/index.html
+++ b/web-frontend/index.html
@@ -39,7 +39,7 @@
         </p>
 
         <button id="submit-btn">Submit</button>
-        <div class="field output">
+        <div class="field output" id="output-field">
             <div class="field box" id="stdout-field">Stdout: </div>
             <div class="field box" id="stderr-field">Stderr: </div>
             <div class="field box" id="err-field">Error: </div>


### PR DESCRIPTION
- fixed an issue where error content wasn't going into the right DOM node
- fixed an issue where an error caught in `runCall` would delete the other `stdout` and `stderr` fields, causing subsequent submissions to fail regardless of correctness 
  -  now those fields are just hidden and re-shown
- errors are now stringified within the `stringify` function

This is to address #91

Let me know if the stringification format should be modified. Right now it essentially just enumerates the error object and puts any non-null inner fields into a comma-separated list. If there are none, it simply outputs "none". I tested this with syntax errors, logic errors, and errorless submissions, and it seemed to work well. 

The only issue that I've noticed is that there seems to be an issue in the way the backend is propagating errors; for example, a null pointer dereference returns no error, even though there is a clear segfault:
<img width="1594" alt="Screenshot 2024-06-19 at 1 01 20 PM" src="https://github.com/camerondurham/codecanvas/assets/15022354/e7289a5f-db84-4de9-98e7-99510c1e398e">
