### PR TITLE
propagating compiler errors

### DIFF
--- a/engine/controller/controller.go
+++ b/engine/controller/controller.go
@@ -105,9 +105,9 @@ func (ac *AsyncController) SubmitRequest(runprops *Props) *CtrlRunOutput {
 				if commandErr != nil {
 					print2.DebugPrintf("error preparing command: output=%v\n \nerror=%v", preRunOut, commandErr)
 					return &CtrlRunOutput{
-						ControllerErr: PreRunError,
+						ControllerErr: nil,
 						RunOutput:     preRunOut,
-						CommandErr:    nil,
+						CommandErr:    commandErr,
 					}
 				}
 			}

--- a/engine/controller/controller.go
+++ b/engine/controller/controller.go
@@ -102,11 +102,11 @@ func (ac *AsyncController) SubmitRequest(runprops *Props) *CtrlRunOutput {
 
 			if runprops.PreRunProps != nil {
 				preRunOut, commandErr := agent.SafeRunCmd(preRunProps)
-				print2.DebugPrintf("error preparing command: output=%v\n \nerror=%v", preRunOut, commandErr)
 				if commandErr != nil {
+					print2.DebugPrintf("error preparing command: output=%v\n \nerror=%v", preRunOut, commandErr)
 					return &CtrlRunOutput{
 						ControllerErr: PreRunError,
-						RunOutput:     nil,
+						RunOutput:     preRunOut,
 						CommandErr:    nil,
 					}
 				}

--- a/engine/controller/controller_test.go
+++ b/engine/controller/controller_test.go
@@ -98,6 +98,13 @@ func TestSubmitRequest(t *testing.T) {
 		Stderr: "world",
 	}
 
+	errorCaseOutput := &runtime.RunOutput{
+		Stdout: "",
+		Stderr: "compilation error",
+	}
+
+	errorCaseOutputError := errors.New("Error")
+
 	preRunProps := &runtime.RunProps{
 		RunArgs: []string{"echo", "hello", "world"},
 		Timeout: 0,
@@ -296,7 +303,7 @@ func TestSubmitRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "Last runner is ready: pre run cmd error",
+			name: "Last runner is ready: command error",
 			runProps: &Props{
 				PreRunProps: preRunProps,
 				RunProps:    &runtime.RunProps{},
@@ -313,17 +320,17 @@ func TestSubmitRequest(t *testing.T) {
 				{
 					state:                  runtime.Ready,
 					shouldBePickedAsRunner: true,
-					returnOutput:           happyCaseOutput,
-					returnErr:              nil,
+					returnOutput:           errorCaseOutput,
+					returnErr:              errorCaseOutputError,
 					writeErr:               nil,
-					preRunErr:              errors.New("some error"),
+					preRunErr:              nil,
 					preRunCmd:              preRunProps,
 				},
 			},
 			want: CtrlRunOutput{
-				ControllerErr: PreRunError,
-				RunOutput:     nil,
-				CommandErr:    nil,
+				ControllerErr: nil,
+				RunOutput:     errorCaseOutput,
+				CommandErr:    errorCaseOutputError,
 			},
 		}}
 

--- a/engine/process/main.go
+++ b/engine/process/main.go
@@ -98,10 +98,14 @@ func main() {
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
 	err = cmd.Run()
 
 	if err != nil {
 		print.ProcDebug("error running process: %v\n", err)
-		os.Exit(ERunningProc)
+		// os.Exit(ERunningProc)
+		if cast, ok := err.(*exec.ExitError); ok {
+			os.Exit(cast.ExitCode())
+		}
 	}
 }

--- a/engine/process/main.go
+++ b/engine/process/main.go
@@ -103,8 +103,19 @@ func main() {
 
 	if err != nil {
 		print.ProcDebug("error running process: %v\n", err)
-		// os.Exit(ERunningProc)
 		if cast, ok := err.(*exec.ExitError); ok {
+			if ws, ok := cast.Sys().(syscall.WaitStatus); ok {
+				if ws.Signaled() {
+					// more verbose err message
+					cmd.Stderr.Write([]byte(err.Error()))
+
+					// signal exit code: 128 + signal code
+					os.Exit(128 + int(ws.Signal()))
+				}
+			}
+
+			// if for some reason we can't get the wait status then we
+			// can just get the (probably incorrect) error code from the cast
 			os.Exit(cast.ExitCode())
 		}
 	}

--- a/server/api/v2/types.go
+++ b/server/api/v2/types.go
@@ -22,5 +22,5 @@ type RunResponse struct {
 	// Stderr is standard error stream from running program
 	Stderr string `json:"stderr"`
 	// Error result from either compilation or runtime errors. Will be nil if both compilation and runtime were successful.
-	Error error `json:"error"`
+	Error string `json:"error"`
 }

--- a/server/main.go
+++ b/server/main.go
@@ -84,7 +84,10 @@ func (rs RunnerServer) runHandler(w http.ResponseWriter, r *http.Request) {
 	output := api.RunResponse{
 		Stdout: RunnerOutput.Stdout,
 		Stderr: RunnerOutput.Stderr,
-		Error:  RunnerOutput.CommandError,
+		// Error:  RunnerOutput.CommandError.Error(),
+	}
+	if RunnerOutput.CommandError != nil {
+		output.Error = RunnerOutput.CommandError.Error()
 	}
 
 	err = json.NewEncoder(w).Encode(output)

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -98,7 +98,7 @@ int main() {
 			args: args{
 				r: newRequest("POST", "url", api.RunRequest{
 					Source: "print(\"hello\")",
-					Lang:   coderunner.Go.Name,
+					Lang:   "random-lang",
 				}),
 				expectedStatusCode: 400,
 			},

--- a/server/mock-server/main.go
+++ b/server/mock-server/main.go
@@ -5,10 +5,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	v2 "github.com/runner-x/runner-x/server/api/v2"
 	"log"
 	"net/http"
 	"time"
+
+	v2 "github.com/runner-x/runner-x/server/api/v2"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -41,7 +42,7 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 	output := v2.RunResponse{
 		Stdout: "hello world",
 		Stderr: "",
-		Error:  nil,
+		Error:  "",
 	}
 
 	err := json.NewEncoder(w).Encode(output)

--- a/web-frontend/js/config-utils.js
+++ b/web-frontend/js/config-utils.js
@@ -6,8 +6,8 @@ function getSelectedLanguage() {
 const runnerConfig = {
   getSelectedLanguage: getSelectedLanguage,
   // Uncomment for local testing
-  url: "http://localhost:10100/api/v1/",
-  // url: "https://runner.fly.dev/api/v1/",
+  // url: "http://localhost:10100/api/v1/",
+  url: "https://runner.fly.dev/api/v1/",
   runEndpoint: "run",
   langEndpoint: "languages",
 };

--- a/web-frontend/js/config-utils.js
+++ b/web-frontend/js/config-utils.js
@@ -6,8 +6,8 @@ function getSelectedLanguage() {
 const runnerConfig = {
   getSelectedLanguage: getSelectedLanguage,
   // Uncomment for local testing
-  // url: "http://localhost:10100/api/v1/",
-  url: "https://runner.fly.dev/api/v1/",
+  url: "http://localhost:10100/api/v1/",
+  // url: "https://runner.fly.dev/api/v1/",
   runEndpoint: "run",
   langEndpoint: "languages",
 };

--- a/web-frontend/js/run-request.js
+++ b/web-frontend/js/run-request.js
@@ -19,6 +19,7 @@ function runRequest() {
         reject({
           status: this.status,
           statusText: xhr.statusText,
+          body: xhr.response
         });
       }
     };
@@ -26,6 +27,7 @@ function runRequest() {
       reject({
         status: this.status,
         statusText: xhr.statusText,
+        body: xhr.response
       });
     };
     xhr.send(JSON.stringify(req));

--- a/web-frontend/js/run-request.js
+++ b/web-frontend/js/run-request.js
@@ -67,23 +67,22 @@ async function runCall() {
     .then(function(result) {
       let out = JSON.parse(result);
 
-      out["error"] = stringify(out["error"]);
 
       stdout.innerHTML =
-        "Stdout: " + out["stdout"].replace(/\n/g, "<br>");
+        "<pre>Stdout: " + out["stdout"] + "</pre>";
       stdout.removeAttribute("hidden");
 
       stderr.innerHTML =
-        "Stderr: " + out["stderr"];
+        "<pre>Stderr: " + out["stderr"] + "</pre>";
       stderr.removeAttribute("hidden");
 
-      error.innerHTML = "Error: " + out["error"];
+      error.innerHTML = "<pre>Error: " + out["error"] + "</pre>";
     })
     .catch(function(err) {
       console.log(err);
       stdout.setAttribute("hidden", true);
       stderr.setAttribute("hidden", true);
-      error.innerHTML = "Error: " + stringify(err);
+      error.innerHTML = "<pre>Error: " + stringify(err) + "</pre>";
     });
 }
 

--- a/web-frontend/style/main.css
+++ b/web-frontend/style/main.css
@@ -35,7 +35,7 @@
 
     .field {
         background-color: #d8d8d8;
-        color:#282828;
+        color: #282828;
     }
 }
 
@@ -108,6 +108,10 @@ footer {
 
 .box {
     width: 90%;
+}
+
+pre {
+    text-wrap: balance;
 }
 
 #wrapper {


### PR DESCRIPTION
## WIP 
Meant to address #115 

- `process` now propagates exit code of the command it's running 
- xhr response on frontend also holds a body field to hold error messages from bad requests (>= 400 status code)

Still working on: 
- [x] error handling for runtime errors 
- [ ] standardized error structure 